### PR TITLE
Create persistence files on demand

### DIFF
--- a/bike_track.c
+++ b/bike_track.c
@@ -32,8 +32,19 @@ Component components[MAX_COMPONENTS] = {
 int recordCount = 0;
 double bikeWeight = 0.0;
 
-void saveRecords();
-void saveComponents();
+void saveRecords() {
+    FILE* file = fopen("records.txt", "w");
+    if (file == NULL) {
+        printf("Error saving records.\n");
+        return;
+    }
+    fprintf(file, "%d\n", recordCount);
+    for (int i = 0; i < recordCount; i++) {
+        fprintf(file, "%s\n", records[i].date);
+        fprintf(file, "%s\n", records[i].description);
+    }
+    fclose(file);
+}
 
 void loadRecords() {
     FILE* file = fopen("records.txt", "r");
@@ -94,16 +105,15 @@ void loadRecords() {
     }
 }
 
-void saveRecords() {
-    FILE* file = fopen("records.txt", "w");
+void saveComponents() {
+    FILE* file = fopen("components.txt", "w");
     if (file == NULL) {
-        printf("Error saving records.\n");
+        printf("Error saving components.\n");
         return;
     }
-    fprintf(file, "%d\n", recordCount);
-    for (int i = 0; i < recordCount; i++) {
-        fprintf(file, "%s\n", records[i].date);
-        fprintf(file, "%s\n", records[i].description);
+    fprintf(file, "%.2f\n", bikeWeight);
+    for (int i = 0; i < MAX_COMPONENTS; i++) {
+        fprintf(file, "%d\n", components[i].wearLevel);
     }
     fclose(file);
 }
@@ -140,19 +150,6 @@ void loadComponents() {
     if (sanitized) {
         saveComponents();
     }
-}
-
-void saveComponents() {
-    FILE* file = fopen("components.txt", "w");
-    if (file == NULL) {
-        printf("Error saving components.\n");
-        return;
-    }
-    fprintf(file, "%.2f\n", bikeWeight);
-    for (int i = 0; i < MAX_COMPONENTS; i++) {
-        fprintf(file, "%d\n", components[i].wearLevel);
-    }
-    fclose(file);
 }
 
 void addRecord() {

--- a/bike_track.c
+++ b/bike_track.c
@@ -32,19 +32,66 @@ Component components[MAX_COMPONENTS] = {
 int recordCount = 0;
 double bikeWeight = 0.0;
 
+void saveRecords();
+void saveComponents();
+
 void loadRecords() {
     FILE* file = fopen("records.txt", "r");
     if (file == NULL) {
-        printf("No maintenance records found.\n");
+        printf("No maintenance records found. Creating records.txt.\n");
+        recordCount = 0;
+        saveRecords();
         return;
     }
-    fscanf(file, "%d\n", &recordCount);
-    for (int i = 0; i < recordCount; i++) {
-        fscanf(file, "%10s\n", records[i].date);
-        fgets(records[i].description, 256, file);
-        records[i].description[strcspn(records[i].description, "\n")] = 0; // remove newline character
+
+    int count = 0;
+    if (fscanf(file, "%d\n", &count) != 1) {
+        printf("Unable to read maintenance records count. Resetting records file.\n");
+        recordCount = 0;
+        fclose(file);
+        saveRecords();
+        return;
     }
+
+    int sanitized = 0;
+    if (count < 0) {
+        printf("Invalid maintenance record count encountered. Resetting to zero.\n");
+        count = 0;
+        sanitized = 1;
+    }
+
+    if (count > MAX_RECORDS) {
+        printf("Warning: Only the first %d of %d maintenance records will be loaded.\n", MAX_RECORDS, count);
+    }
+
+    int storedRecords = 0;
+    for (int i = 0; i < count; i++) {
+        MaintenanceRecord tempRecord;
+        if (fscanf(file, "%10s\n", tempRecord.date) != 1) {
+            printf("Encountered an incomplete maintenance record entry.\n");
+            sanitized = 1;
+            break;
+        }
+
+        if (fgets(tempRecord.description, sizeof(tempRecord.description), file) == NULL) {
+            printf("Encountered an incomplete maintenance record description.\n");
+            sanitized = 1;
+            break;
+        }
+
+        tempRecord.description[strcspn(tempRecord.description, "\n")] = 0; // remove newline character
+
+        if (storedRecords < MAX_RECORDS) {
+            records[storedRecords++] = tempRecord;
+        }
+    }
+
     fclose(file);
+    recordCount = storedRecords;
+
+    if (sanitized) {
+        saveRecords();
+    }
 }
 
 void saveRecords() {
@@ -64,14 +111,35 @@ void saveRecords() {
 void loadComponents() {
     FILE* file = fopen("components.txt", "r");
     if (file == NULL) {
-        printf("No components data found.\n");
+        printf("No components data found. Creating components.txt with default values.\n");
+        bikeWeight = 0.0;
+        for (int i = 0; i < MAX_COMPONENTS; i++) {
+            components[i].wearLevel = 0;
+        }
+        saveComponents();
         return;
     }
-    fscanf(file, "%lf\n", &bikeWeight);
-    for (int i = 0; i < MAX_COMPONENTS; i++) {
-        fscanf(file, "%d\n", &components[i].wearLevel);
+
+    int sanitized = 0;
+    if (fscanf(file, "%lf\n", &bikeWeight) != 1) {
+        printf("Unable to read bike weight from components file. Resetting to 0.\n");
+        bikeWeight = 0.0;
+        sanitized = 1;
     }
+
+    for (int i = 0; i < MAX_COMPONENTS; i++) {
+        if (fscanf(file, "%d\n", &components[i].wearLevel) != 1) {
+            printf("Missing wear level information for %s. Resetting to 0.\n", components[i].name);
+            components[i].wearLevel = 0;
+            sanitized = 1;
+        }
+    }
+
     fclose(file);
+
+    if (sanitized) {
+        saveComponents();
+    }
 }
 
 void saveComponents() {


### PR DESCRIPTION
## Summary
- ensure maintenance records storage is created when absent and rewrite the file when entries are incomplete so saved updates persist
- automatically create the components data file with default values and rewrite it after sanitizing missing or invalid fields
- declare the persistence helpers needed by the loaders so the compiler accepts the new save calls

## Testing
- gcc -Wall -Wextra -std=c11 bike_track.c -o bike_track

------
https://chatgpt.com/codex/tasks/task_e_68e3b9bbc500832d97e763bad66fad54